### PR TITLE
feat: add Product Service Integration

### DIFF
--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,5 +1,5 @@
 const API_PATHS = {
-  product: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  product: "https://gyc0omak64.execute-api.eu-west-1.amazonaws.com/prod",
   order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -9,7 +9,7 @@ export function useAvailableProducts() {
     "available-products",
     async () => {
       const res = await axios.get<AvailableProduct[]>(
-        `${API_PATHS.bff}/product/available`
+        `${API_PATHS.product}/products`
       );
       return res.data;
     }
@@ -29,7 +29,7 @@ export function useAvailableProduct(id?: string) {
     ["product", { id }],
     async () => {
       const res = await axios.get<AvailableProduct>(
-        `${API_PATHS.bff}/product/${id}`
+        `${API_PATHS.product}/products/${id}`
       );
       return res.data;
     },


### PR DESCRIPTION
## Description
This PR integrates `Product Service` with the frontend application.

## Screenshots
<img width="1412" alt="Screenshot 2024-06-15 at 19 05 13" src="https://github.com/anton-paskanny/nodejs-aws-shop-react/assets/16050005/d017aaa0-aa91-42b0-8a8f-87d8fe4dc241">


## Changes Made
- Integrated frontend application with `/products` API from Product Service.
- Products retrieved from Product Service are now displayed on the frontend.

## Checklist
- [X] Your own Frontend application is integrated with Product Service (/products API) and products from Product Service are represented on Frontend - here is [the link to Product Service PR](https://github.com/anton-paskanny/nodejs-aws-shop-react-backend/pull/1)

## Useful links
- [BE Repository](https://github.com/anton-paskanny/nodejs-aws-shop-react-backend)
- [Cloud Front Distribution](https://d3u8c9svdogi62.cloudfront.net/)