### PR TITLE
Task 7: Integrate Auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.2.0",
         "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
+        "react-toastify": "^10.0.5",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -6273,6 +6274,26 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
@@ -11873,6 +11894,21 @@
       "requires": {
         "history": "^5.2.0",
         "react-router": "6.3.0"
+      }
+    },
+    "react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "requires": {
+        "clsx": "^2.1.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+        }
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
+    "react-toastify": "^10.0.5",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -31,17 +31,25 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
       return;
     }
 
-    // Get the presigned URL
-    const response = await axios({
+    const authToken = localStorage.getItem("authorization_token");
+
+    const requestOptions = {
       method: "GET",
       url,
       params: {
         name: encodeURIComponent(file.name),
       },
-      headers: {
-        Authorization: `Basic ${localStorage.getItem("authorization_token")}`,
-      },
-    });
+      headers: {},
+    };
+
+    if (authToken) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      requestOptions.headers.Authorization = `Basic ${authToken}`;
+    }
+
+    // Get the presigned URL
+    const response = await axios(requestOptions);
     console.log("File to upload: ", file.name);
     console.log("Uploading to: ", response.data);
     const result = await fetch(response.data, {

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -27,7 +27,7 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
     console.log("uploadFile to", url);
 
     if (!file) {
-      console.log('No file was found');
+      console.log("No file was found");
       return;
     }
 
@@ -37,6 +37,9 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
       url,
       params: {
         name: encodeURIComponent(file.name),
+      },
+      headers: {
+        Authorization: `Basic ${localStorage.getItem("authorization_token")}`,
       },
     });
     console.log("File to upload: ", file.name);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,11 +7,32 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: { refetchOnWindowFocus: false, retry: false, staleTime: Infinity },
+    mutations: { retry: false },
   },
+});
+
+queryClient.getQueryCache().subscribe((event) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (event?.type === "error" && event?.query?.state?.error) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const error = event.query.state.error;
+
+    if (error.response?.status === 401) {
+      toast.error("Unauthorized access. Please log in.");
+    } else if (error.response?.status === 403) {
+      toast.error(
+        "Forbidden access. You don't have permission to view this resource."
+      );
+    }
+  }
 });
 
 if (import.meta.env.DEV) {
@@ -29,6 +50,7 @@ root.render(
         <ThemeProvider theme={theme}>
           <CssBaseline />
           <App />
+          <ToastContainer />
         </ThemeProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,32 +7,36 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
+import axios, { AxiosError } from "axios";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
+axios.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError) => {
+    switch (error.response?.status) {
+      case 401:
+        toast.error("Unauthorized access. Please log in.");
+        break;
+      case 403:
+        toast.error(
+          "Forbidden access. You don't have permission to view this resource."
+        );
+        break;
+    }
+    return Promise.reject(error);
+  }
+);
+
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { refetchOnWindowFocus: false, retry: false, staleTime: Infinity },
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: Infinity,
+    },
     mutations: { retry: false },
   },
-});
-
-queryClient.getQueryCache().subscribe((event) => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (event?.type === "error" && event?.query?.state?.error) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const error = event.query.state.error;
-
-    if (error.response?.status === 401) {
-      toast.error("Unauthorized access. Please log in.");
-    } else if (error.response?.status === 403) {
-      toast.error(
-        "Forbidden access. You don't have permission to view this resource."
-      );
-    }
-  }
 });
 
 if (import.meta.env.DEV) {


### PR DESCRIPTION
### Important notes

To handle 401 and 403 error I've installed `react-toastify` library.

### Checklist

#### Core Tasks

- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)

#### Additional Tasks
- [x] +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.

### Screenshots

#### 401 error handling on FE side
<img width="1434" alt="Screenshot 2024-07-14 at 18 04 16" src="https://github.com/user-attachments/assets/7eb3cd93-0246-48c6-9fe9-79a98a383f2f">

#### 403 error handling on FE side
<img width="1437" alt="Screenshot 2024-07-14 at 18 08 00" src="https://github.com/user-attachments/assets/6eb80152-d404-45f8-bad5-eaef66554455">
